### PR TITLE
Add Flutter frontend prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __init__
 configs/firebase_config.json
 configs/firebase_service_account.json
 configs/firebase_service_account.json
+flutter_frontend/build/
+flutter_frontend/.dart_tool/
+flutter_frontend/.idea/

--- a/flutter_frontend/README.md
+++ b/flutter_frontend/README.md
@@ -1,0 +1,14 @@
+# Talent Flutter Frontend
+
+This Flutter project provides the client interface for the Talent platform. It contains only the front-end and simulates API calls.
+
+## Getting Started
+
+Install Flutter SDK, then run:
+
+```bash
+flutter pub get
+flutter run
+```
+
+The app currently uses mock services and can connect to a Django backend later.

--- a/flutter_frontend/lib/main.dart
+++ b/flutter_frontend/lib/main.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'screens/onboarding_screen.dart';
+import 'screens/role_selection_screen.dart';
+import 'screens/login_screen.dart';
+import 'screens/home_screen.dart';
+import 'screens/offer_detail_screen.dart';
+
+void main() {
+  runApp(TalentApp());
+}
+
+class TalentApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'Talent',
+      theme: ThemeData(primarySwatch: Colors.deepPurple),
+      initialRoute: '/',
+      routes: {
+        '/': (context) => OnboardingScreen(),
+        '/role': (context) => RoleSelectionScreen(),
+        '/login': (context) => LoginScreen(),
+        '/home': (context) => HomeScreen(),
+        '/detail': (context) => OfferDetailScreen(),
+      },
+    );
+  }
+}

--- a/flutter_frontend/lib/models/offer.dart
+++ b/flutter_frontend/lib/models/offer.dart
@@ -1,0 +1,25 @@
+class Offer {
+  final String title;
+  final String city;
+  final String country;
+  final String duration;
+  final String salary;
+  final String date;
+  final String overview;
+  final String details;
+  final String imageUrl;
+  bool isFavorite;
+
+  Offer({
+    required this.title,
+    required this.city,
+    required this.country,
+    required this.duration,
+    required this.salary,
+    required this.date,
+    required this.overview,
+    required this.details,
+    required this.imageUrl,
+    this.isFavorite = false,
+  });
+}

--- a/flutter_frontend/lib/models/user.dart
+++ b/flutter_frontend/lib/models/user.dart
@@ -1,0 +1,6 @@
+class AppUser {
+  final String id;
+  final String email;
+
+  AppUser({required this.id, required this.email});
+}

--- a/flutter_frontend/lib/screens/home_screen.dart
+++ b/flutter_frontend/lib/screens/home_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import '../widgets/offer_card.dart';
+import '../services/offer_service.dart';
+import '../models/offer.dart';
+
+class HomeScreen extends StatefulWidget {
+  @override
+  _HomeScreenState createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  late Future<List<Offer>> offers;
+
+  @override
+  void initState() {
+    super.initState();
+    offers = OfferService().getOffers();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Bonjour, David 👋'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              decoration: InputDecoration(
+                hintText: 'Recherche une offre',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(borderRadius: BorderRadius.circular(30)),
+              ),
+            ),
+            SizedBox(height: 16),
+            Expanded(
+              child: FutureBuilder<List<Offer>>(
+                future: offers,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return Center(child: CircularProgressIndicator());
+                  } else if (snapshot.hasError) {
+                    return Center(child: Text('Erreur de chargement'));
+                  } else {
+                    final data = snapshot.data!;
+                    return ListView.builder(
+                      itemCount: data.length,
+                      itemBuilder: (context, index) {
+                        return OfferCard(offer: data[index]);
+                      },
+                    );
+                  }
+                },
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_frontend/lib/screens/login_screen.dart
+++ b/flutter_frontend/lib/screens/login_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import '../widgets/custom_button.dart';
+import '../widgets/rounded_text_field.dart';
+
+class LoginScreen extends StatelessWidget {
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+
+  Future<void> _handleGoogleSignIn() async {
+    final _googleSignIn = GoogleSignIn();
+    try {
+      await _googleSignIn.signIn();
+    } catch (error) {
+      // handle error
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Connexion')),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            CustomButton(
+              text: 'Continue avec Google',
+              color: Colors.redAccent,
+              onPressed: _handleGoogleSignIn,
+            ),
+            SizedBox(height: 20),
+            RoundedTextField(
+              controller: emailController,
+              hintText: 'Adresse mail',
+            ),
+            SizedBox(height: 10),
+            RoundedTextField(
+              controller: passwordController,
+              hintText: 'Mot de passe',
+              obscureText: true,
+            ),
+            SizedBox(height: 20),
+            CustomButton(
+              text: 'Connexion',
+              onPressed: () {
+                Navigator.pushReplacementNamed(context, '/home');
+              },
+            ),
+            TextButton(
+              onPressed: () {},
+              child: Text('Mot de passe oublié ?'),
+            ),
+            Spacer(),
+            TextButton(
+              onPressed: () {},
+              child: Text('Sign up'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_frontend/lib/screens/offer_detail_screen.dart
+++ b/flutter_frontend/lib/screens/offer_detail_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import '../models/offer.dart';
+import '../widgets/custom_button.dart';
+
+class OfferDetailScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final Offer offer = ModalRoute.of(context)!.settings.arguments as Offer;
+    return Scaffold(
+      appBar: AppBar(title: Text(offer.title)),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Image.network(
+              offer.imageUrl,
+              width: double.infinity,
+              height: 200,
+              fit: BoxFit.cover,
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(offer.title,
+                      style:
+                          TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+                  SizedBox(height: 8),
+                  Text('${offer.city}, ${offer.country}'),
+                  SizedBox(height: 8),
+                  Text('Durée: ${offer.duration}'),
+                  Text('Rémunération: ${offer.salary}'),
+                  Text('Date: ${offer.date}'),
+                  SizedBox(height: 16),
+                  DefaultTabController(
+                    length: 2,
+                    child: Column(
+                      children: [
+                        TabBar(
+                          labelColor: Colors.deepPurple,
+                          tabs: [
+                            Tab(text: 'Overview'),
+                            Tab(text: 'Details'),
+                          ],
+                        ),
+                        Container(
+                          height: 200,
+                          child: TabBarView(
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Text(offer.overview),
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Text(offer.details),
+                              )
+                            ],
+                          ),
+                        )
+                      ],
+                    ),
+                  ),
+                  SizedBox(height: 16),
+                  CustomButton(
+                    text: 'Liker ce poste ❤️',
+                    onPressed: () {},
+                  )
+                ],
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_frontend/lib/screens/onboarding_screen.dart
+++ b/flutter_frontend/lib/screens/onboarding_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  @override
+  _OnboardingScreenState createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  int _current = 0;
+  PageController _controller = PageController();
+
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(Duration(seconds: 3), () {
+      Navigator.pushReplacementNamed(context, '/role');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Colors.deepPurple, Colors.lightBlueAccent],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                'CONSTRUISONS ENSEMBLE LES CARRIÈRES DE DEMAIN...',
+                style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: 20),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: Text(
+                  'Étudiants, recruteurs, administration – un seul espace, une seule mission : créer des connexions qui comptent.',
+                  style: TextStyle(color: Colors.white),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              SizedBox(height: 40),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(
+                  3,
+                  (index) => Container(
+                    margin: EdgeInsets.symmetric(horizontal: 4),
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: _current == index
+                          ? Colors.white
+                          : Colors.white.withOpacity(0.3),
+                    ),
+                  ),
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_frontend/lib/screens/role_selection_screen.dart
+++ b/flutter_frontend/lib/screens/role_selection_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../widgets/custom_button.dart';
+
+class RoleSelectionScreen extends StatelessWidget {
+  Future<void> _selectRole(BuildContext context, String role) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('role', role);
+    Navigator.pushNamed(context, '/login');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Welcome !')),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Choisissez votre espace',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 40),
+            CustomButton(
+              text: 'Je suis étudiant.e',
+              color: Colors.deepPurple,
+              onPressed: () => _selectRole(context, 'student'),
+            ),
+            SizedBox(height: 16),
+            CustomButton(
+              text: 'Je suis administrateur.trice',
+              color: Colors.cyan,
+              onPressed: () => _selectRole(context, 'admin'),
+            ),
+            SizedBox(height: 16),
+            CustomButton(
+              text: 'Je suis Recruteur.trice',
+              color: Colors.pinkAccent,
+              onPressed: () => _selectRole(context, 'recruiter'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_frontend/lib/services/auth_service.dart
+++ b/flutter_frontend/lib/services/auth_service.dart
@@ -1,0 +1,8 @@
+import '../models/user.dart';
+
+class AuthService {
+  Future<AppUser> login(String email, String password) async {
+    await Future.delayed(Duration(seconds: 1));
+    return AppUser(id: '1', email: email);
+  }
+}

--- a/flutter_frontend/lib/services/offer_service.dart
+++ b/flutter_frontend/lib/services/offer_service.dart
@@ -1,0 +1,31 @@
+import '../models/offer.dart';
+
+class OfferService {
+  Future<List<Offer>> getOffers() async {
+    await Future.delayed(Duration(seconds: 2));
+    return [
+      Offer(
+        title: 'DataWave Solutions',
+        city: 'Paris',
+        country: 'France',
+        duration: '6 mois',
+        salary: '1000€',
+        date: 'Septembre 2026',
+        overview: 'Mission principale',
+        details: 'Responsabilités, compétences',
+        imageUrl: 'https://via.placeholder.com/150',
+      ),
+      Offer(
+        title: 'Tech Innovators',
+        city: 'Lyon',
+        country: 'France',
+        duration: '3 mois',
+        salary: '800€',
+        date: 'Juin 2026',
+        overview: 'Découvrir',
+        details: 'Apprendre',
+        imageUrl: 'https://via.placeholder.com/150',
+      ),
+    ];
+  }
+}

--- a/flutter_frontend/lib/widgets/custom_button.dart
+++ b/flutter_frontend/lib/widgets/custom_button.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class CustomButton extends StatelessWidget {
+  final String text;
+  final VoidCallback onPressed;
+  final Color? color;
+
+  const CustomButton({
+    Key? key,
+    required this.text,
+    required this.onPressed,
+    this.color,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: color ?? Theme.of(context).primaryColor,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+        padding: EdgeInsets.symmetric(vertical: 12),
+      ),
+      onPressed: onPressed,
+      child: Text(text),
+    );
+  }
+}

--- a/flutter_frontend/lib/widgets/offer_card.dart
+++ b/flutter_frontend/lib/widgets/offer_card.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import '../models/offer.dart';
+
+class OfferCard extends StatelessWidget {
+  final Offer offer;
+
+  const OfferCard({Key? key, required this.offer}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.symmetric(vertical: 8),
+      child: InkWell(
+        onTap: () => Navigator.pushNamed(context, '/detail', arguments: offer),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Row(
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Image.network(
+                  offer.imageUrl,
+                  width: 60,
+                  height: 60,
+                  fit: BoxFit.cover,
+                ),
+              ),
+              SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(offer.title,
+                        style: TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.bold)),
+                    SizedBox(height: 4),
+                    Text('${offer.city}, ${offer.country}'),
+                    Text(offer.salary),
+                  ],
+                ),
+              ),
+              IconButton(
+                icon: Icon(
+                  offer.isFavorite ? Icons.favorite : Icons.favorite_border,
+                  color: Colors.pink,
+                ),
+                onPressed: () {},
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_frontend/lib/widgets/rounded_text_field.dart
+++ b/flutter_frontend/lib/widgets/rounded_text_field.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class RoundedTextField extends StatelessWidget {
+  final TextEditingController controller;
+  final String hintText;
+  final bool obscureText;
+
+  const RoundedTextField({
+    Key? key,
+    required this.controller,
+    required this.hintText,
+    this.obscureText = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      obscureText: obscureText,
+      decoration: InputDecoration(
+        hintText: hintText,
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(30)),
+        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      ),
+    );
+  }
+}

--- a/flutter_frontend/pubspec.yaml
+++ b/flutter_frontend/pubspec.yaml
@@ -1,0 +1,22 @@
+name: talent_frontend
+description: Frontend Flutter app for Talent project
+version: 0.1.0
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.5
+  shared_preferences: ^2.0.15
+  google_sign_in: ^6.1.0
+  font_awesome_flutter: ^10.4.0
+  provider: ^6.0.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- set up Flutter project structure under `flutter_frontend`
- implement onboarding, role selection, login, home and offer detail screens
- create reusable widgets for buttons, rounded text fields and offer cards
- add data models and mock services
- include Flutter dependencies in `pubspec.yaml`
- update `.gitignore` for Flutter build files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68655b30eeb48324ac3e4a05d95ae79d